### PR TITLE
Added lang=None to get_tts for compatibility

### DIFF
--- a/ovos_tts_plugin_mimic2/__init__.py
+++ b/ovos_tts_plugin_mimic2/__init__.py
@@ -30,7 +30,7 @@ class Mimic2TTSPlugin(TTS):
                                               Mimic2TTSValidator(self), 'wav')
         self.url = config.get("url", "https://mimic-api.mycroft.ai/synthesize")
 
-    def get_tts(self, sentence, wav_file):
+    def get_tts(self, sentence, wav_file, lang=None):
         """Fetch tts audio using tacotron endpoint.
 
         Arguments:


### PR DESCRIPTION
Done nothing, just want this TTS to be able to be called with the lang parameter for consistency with the other TTS.
To the best of my knowledge Mimic only works in English.